### PR TITLE
feat: 새 공간 등록 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "react-mobile-picker": "^1.1.2",
     "react-router-dom": "^7.6.2",
     "sass": "^1.89.2",
-    "swiper": "^11.2.10",
-    "tailwind-scrollbar-hide": "^4.0.0"
+    "swiper": "^11.2.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
@@ -37,6 +36,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
     "postcss": "^8.5.6",
+    "tailwind-scrollbar-hide": "^4.0.0",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       swiper:
         specifier: ^11.2.10
         version: 11.2.10
-      tailwind-scrollbar-hide:
-        specifier: ^4.0.0
-        version: 4.0.0(tailwindcss@3.4.17)
     devDependencies:
       '@eslint/js':
         specifier: ^9.29.0
@@ -84,6 +81,9 @@ importers:
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
+      tailwind-scrollbar-hide:
+        specifier: ^4.0.0
+        version: 4.0.0(tailwindcss@3.4.17)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,26 +7,26 @@ import HomePage from "./pages/HomePage";
 import RecsPage from "./pages/RecsPage";
 import SearchPage from "./pages/SearchPage";
 import FavoritesPage from "./pages/FavoritesPage";
-import MyPage from "./pages/mypage/MyPage";
+import MyPage from "./pages/myPage/MyPage";
 import SpaceDetailPage from "./pages/spacedetail/SpaceDetailPage";
 import ThemeAllPage from "./pages/ThemeAllPage";
 import ThemeDetailPage from "./pages/ThemeDetailPage";
 import SignupPage from "./pages/SignupPage";
-import NoticePage from "./pages/mypage/NoticePage";
-import NoticeDetailPage from "./pages/mypage/NoticeDetailPage";
+import NoticePage from "./pages/myPage/NoticePage";
+import NoticeDetailPage from "./pages/myPage/NoticeDetailPage";
 import PointLayout from "./layouts/PointLayout";
-import MainList from "./components/mypage/point/MainList";
-import PointCharge from "./components/mypage/point/PointCharge";
-import PointDetail from "./components/mypage/point/PointDetail";
+import MainList from "./components/myPage/point/MainList";
+import PointCharge from "./components/myPage/point/PointCharge";
+import PointDetail from "./components/myPage/point/PointDetail";
 import HotSpaceListPage from "./pages/HotSpaceListPage";
-import ProfilePage from "./pages/mypage/ProfilePage";
-import WithdrawalPage from "./pages/mypage/WithdrawalPage";
-import ProposalPage from "./pages/mypage/ProposalPage";
+import ProfilePage from "./pages/myPage/ProfilePage";
+import WithdrawalPage from "./pages/myPage/WithdrawalPage";
+import ProposalPage from "./pages/myPage/ProposalPage";
 import SpaceReviewWritePage from "./pages/spacedetail/SpaceReviewWritePage";
 import LoginPage from "./pages/LoginPage";
 import OauthKakaoCallback from "./components/login/OauthKakaoCallback";
-import PushPage from "./pages/mypage/PushPage";
-import VisitPage from "./pages/mypage/VisitPage";
+import PushPage from "./pages/myPage/PushPage";
+import VisitPage from "./pages/myPage/VisitPage";
 import PublicLayout from "./layouts/PublicLayout";
 import ProtectedLayout from "./layouts/ProtectedLayout";
 import AdminHomePage from "./pages/admin/AdminHomePage";
@@ -36,6 +36,9 @@ import NewNoticePage from "./pages/admin/NewNoticePage";
 import SpaceCongestionDetailPage from "./pages/spacedetail/SpaceCongestionDetailPage";
 import AllAdminRequestsPage from "./pages/admin/AllAdminRequestsPage";
 import AdminRequestDetailPage from "./pages/admin/AdminRequestDetailPage";
+import AdminCreateSpacePage from "./pages/admin/AdminCreateSpacePage";
+import AdminConfirmSpacePage from "./pages/admin/AdminConfirmSpacePage";
+import AdminInitSpaceInfoPage from "./pages/admin/AdminInitSpaceInfoPage";
 
 const publicRoutes: RouteObject[] = [
   {
@@ -86,6 +89,9 @@ const protectedRoutes: RouteObject[] = [
       { path: "notices/new", element: <NewNoticePage /> },
       { path: "all-requests", element: <AllAdminRequestsPage /> },
       { path: "request/:id", element: <AdminRequestDetailPage /> },
+      { path: "create-space", element: <AdminCreateSpacePage /> },
+      { path: "confirm-space", element: <AdminConfirmSpacePage /> },
+      { path: "init-space-info", element: <AdminInitSpaceInfoPage /> },
     ],
   },
 ];

--- a/src/components/detail/SpaceInfoSimple.tsx
+++ b/src/components/detail/SpaceInfoSimple.tsx
@@ -1,0 +1,34 @@
+// src/components/detail/SpaceInfoSimple.tsx
+import type { Space } from "../../constants/dummySpaces";
+import mapSample from "../../assets/map_sample.jpg";
+
+interface Props {
+  space: Space;
+}
+
+const SpaceInfoSimple = ({ space }: Props) => {
+  return (
+    <div className="text-sm text-gray-800 space-y-6">
+      {/* 위치정보 */}
+      <div>
+        <div className="font-semibold mb-2">위치정보</div>
+        <img
+          src={mapSample}
+          alt="지도 미리보기"
+          className="w-full h-28 object-cover rounded-xl mb-2"
+        />
+        <div>{space.address}</div>
+      </div>
+
+       {/* 영업정보 */}
+      <div>
+        <div className="font-semibold mb-2">영업정보</div>
+        <div className="mb-1">운영시간: {space.opening}</div>
+        <div className="mb-1">정기휴무: {space.holiday}</div>
+        <div className="mb-1">전화번호: {space.phone}</div>
+      </div>
+    </div>
+  );
+};
+
+export default SpaceInfoSimple;

--- a/src/components/mapSearch/BottomSheet.tsx
+++ b/src/components/mapSearch/BottomSheet.tsx
@@ -1,6 +1,6 @@
 import type { RefObject } from "react";
-import TabButtons from "./TabButtons";
-import FilterSection from "./FilterSection";
+import TabButtons from "../mapSearch/TabButtons";
+import FilterSection from "../mapSearch/FilterSection";
 import type { TabLabel } from "../../hooks/useSearchFilters";
 
 interface BottomSheetProps {

--- a/src/components/mapSearch/FilterSection.tsx
+++ b/src/components/mapSearch/FilterSection.tsx
@@ -5,7 +5,7 @@ interface FilterSectionProps {
   labels: string[];
   selectedFilters: Record<string, string[]>;
   toggleFilter: (category: TabLabel, label: string) => void;
-  sectionRef: React.RefObject<HTMLDivElement | null>;
+  sectionRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 const FilterSection = ({
@@ -16,7 +16,7 @@ const FilterSection = ({
   sectionRef,
 }: FilterSectionProps) => {
   return (
-    <div ref={sectionRef} className="mb-6">
+    <div ref={sectionRef ?? undefined} className="mb-6">
       <h2 className="text-sm mb-2">{title}</h2>
       <div className="flex flex-wrap gap-2">
         {labels.map((label) => {

--- a/src/components/mapSearch/SearchResultSheet.tsx
+++ b/src/components/mapSearch/SearchResultSheet.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import SpaceListCard from "../space/SpaceListCard";
 import dummySpaces from "../../constants/dummySpaces";
 import type { TabLabel } from "../../hooks/useSearchFilters";
-import TabButtons from "./TabButtons";
+import TabButtons from "../mapSearch/TabButtons";
 import type { Space } from "../../types/space";
 
 interface SearchResultSheetProps {

--- a/src/components/mapSearch/TabButtons.tsx
+++ b/src/components/mapSearch/TabButtons.tsx
@@ -9,7 +9,7 @@ const TabButtons = ({ onClick, selectedFilters }: TabButtonsProps) => {
   const tabs: TabLabel[] = ["이용 목적", "공간 종류", "분위기", "부가시설", "지역"];
 
   return (
-    <div className="flex gap-1 overflow-x-auto px-2 pt-3 pb-2">
+    <div className="flex justify-center gap-2 overflow-x-auto px-2 pt-3 pb-2">
       {tabs.map((tab) => {
         const selections = selectedFilters[tab] || [];
         let label: string;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import TopHeader from "../components/TopHeader";
-import SearchControls from "../components/mapsearch/SearchControls";
-import BottomSheet from "../components/mapsearch/BottomSheet";
-import SearchMode from "../components/mapsearch/SearchMode";
+import SearchControls from "../components/mapSearch/SearchControls";
+import BottomSheet from "../components/mapSearch/BottomSheet";
+import SearchMode from "../components/mapSearch/SearchMode";
 import { useSearchFilters } from "../hooks/useSearchFilters";
-import KakaoMap from "../components/mapsearch/KakaoMap";
-import SearchResultSheet from "../components/mapsearch/SearchResultSheet";
+import KakaoMap from "../components/mapSearch/KakaoMap";
+import SearchResultSheet from "../components/mapSearch/SearchResultSheet";
 import { useSearchMode } from "../contexts/SearchModeContext";
 import type { Space } from "../types/space";
-import PlaceSelectSheet from "../components/mapsearch/PlaceSelectSheet";
+import PlaceSelectSheet from "../components/mapSearch/PlaceSelectSheet";
 
 const SearchPage = () => {
   useEffect(() => {

--- a/src/pages/admin/AdminConfirmSpacePage.tsx
+++ b/src/pages/admin/AdminConfirmSpacePage.tsx
@@ -1,0 +1,60 @@
+import TopHeader from "../../components/TopHeader";
+import SpaceInfoSimple from "../../components/detail/SpaceInfoSimple";
+import dummySpaces from "../../constants/dummySpaces";
+import type { Space } from "../../constants/dummySpaces";
+import { useNavigate } from "react-router-dom";
+
+const AdminConfirmSpacePage = () => {
+  const navigate = useNavigate();
+
+  // 예시: 첫 번째 공간 데이터 사용
+  const space: Space = dummySpaces[0];
+
+  const handleConfirm = () => {
+    navigate("/admin/init-space-info", {
+      state: {
+        placeName: space.name,
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-white px-4 pt-6 pb-32 relative">
+      <TopHeader title="새 공간 등록" />
+
+      {/* 안내 문구 */}
+      <p className="mt-6 text-center text-sm text-gray-700 whitespace-pre-line mb-6">
+        이 공간 정보를 등록하시겠습니까?
+        {"\n"}확인 후 진행해주세요.
+      </p>
+
+      {/* 장소명 */}
+      <h2 className="text-xl font-bold mb-2">{space.name}</h2>
+
+      {/* 정보 박스 */}
+      <div className="border border-gray-300 bg-white rounded-lg p-4 mb-10">
+        <SpaceInfoSimple space={space} />
+      </div>
+
+      {/* 하단 고정 버튼 */}
+      <div className="fixed bottom-0 left-0 right-0 max-w-[400px] w-full mx-auto bg-white px-4 py-4">
+        <div className="flex justify-between gap-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex-1 py-2 border border-gray-300 rounded-md text-sm font-semibold text-gray-600 bg-white"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="flex-1 py-2 rounded-md text-sm font-semibold text-white bg-[#4cb1f1]"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminConfirmSpacePage;

--- a/src/pages/admin/AdminCreateSpacePage.tsx
+++ b/src/pages/admin/AdminCreateSpacePage.tsx
@@ -1,0 +1,100 @@
+// src/pages/AdminCreateSpacePage.tsx
+import TopHeader from "../../components/TopHeader";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom"; // 추가
+
+const AdminCreateSpacePage = () => {
+  const [placeName, setPlaceName] = useState("");
+  const [googleMapsLink, setGoogleMapsLink] = useState("");
+  const [isValidationFailed, setIsValidationFailed] = useState(false); // 실패 상태
+
+  const navigate = useNavigate(); // 함수 내부에 추가
+
+  const handleFetchInfo = () => {
+    // 항상 성공 처리
+    setIsValidationFailed(false);
+
+    navigate("/admin/confirm-space", {
+      state: {
+        placeName,
+        googleMapsLink,
+      },
+    });
+    
+    // const normalizedPlaceName = placeName.trim().toLowerCase();
+    // const normalizedLink = googleMapsLink.trim().toLowerCase();
+
+    // if (!normalizedLink.includes(normalizedPlaceName) || !normalizedPlaceName) {
+    //   setIsValidationFailed(true);
+    // } else {
+    //   setIsValidationFailed(false);
+
+    //   // 성공 시 확인 페이지로 이동 + state로 정보 전달
+    //   navigate("/admin/confirm-space", {
+    //     state: {
+    //       placeName,
+    //       googleMapsLink,
+    //     },
+    //   });
+    // }
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* 상단 헤더 */}
+      <TopHeader title="새 공간 등록" />
+
+      {/* 본문 */}
+      <div className="px-4 py-6">
+        <p className="text-sm text-gray-700 mb-6 text-center">
+          등록할 공간의 정보를 입력해주세요.
+        </p>
+
+        <div className="rounded-lg border border-gray-200 p-4 bg-white">
+          <div className="mb-8">
+            <label className="block text-sm mb-1">장소명</label>
+            <input
+              type="text"
+              placeholder="공간 이름을 작성해주세요."
+              value={placeName}
+              onChange={(e) => setPlaceName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring focus:border-[#4cb1f1]"
+            />
+          </div>
+
+          <div className="mb-10">
+            <label className="block text-sm mb-1">구글 맵스 링크</label>
+            <input
+              type="text"
+              placeholder="공간 관련 정보를 입력해주세요."
+              value={googleMapsLink}
+              onChange={(e) => setGoogleMapsLink(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring focus:border-[#4cb1f1]"
+            />
+          </div>
+
+          <div className="flex justify-center mb-6">
+            <button
+              onClick={handleFetchInfo}
+              className="w-fit bg-[#4cb1f1] text-white text-sm py-2 px-6 rounded-full"
+            >
+              공간 정보 가져오기
+            </button>
+          </div>
+        </div>
+
+        {/* 실패 메시지 박스 (조건부 렌더링) */}
+        {isValidationFailed && (
+          <div className="flex justify-center w-full mt-8">
+            <div className="bg-gray-100 text-sm text-gray-700 font-semibold rounded-md px-4 py-3 text-center whitespace-pre-line w-full max-w-[640px]">
+              공간 조회에 실패했습니다.
+              {"\n"}공간명과 링크를 다시 확인해주세요.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminCreateSpacePage;

--- a/src/pages/admin/AdminHomePage.tsx
+++ b/src/pages/admin/AdminHomePage.tsx
@@ -42,7 +42,10 @@ const AdminHomePage = () => {
       <div className="px-5 py-2 mb-4">
         <div className="text-m font-bold text-left">빠른 작업</div>
         <div className="flex gap-4 my-5">
-          <button className="bg-white flex flex-col items-center w-28 h-28 py-8 rounded-xl shadow-sm border border-[#E7EDF3] transition">
+          <button
+            onClick={() => navigate("/admin/create-space")} // 경로 연결 추가
+            className="bg-white flex flex-col items-center w-28 h-28 py-8 rounded-xl shadow-sm border border-[#E7EDF3] transition"
+          >
             <FaPen className="text-[#737373] mb-1" size={24} />
             <span className="text-sm text-[#737373] font-semibold">
               새 공간 등록

--- a/src/pages/admin/AdminInitSpaceInfoPage.tsx
+++ b/src/pages/admin/AdminInitSpaceInfoPage.tsx
@@ -1,0 +1,73 @@
+// src/pages/AdminInitSpaceInfoPage.tsx
+import TopHeader from "../../components/TopHeader";
+import FilterSection from "../../components/mapSearch/FilterSection";
+import type { TabLabel } from "../../hooks/useSearchFilters";
+import { useState } from "react";
+
+import { useLocation } from "react-router-dom";
+
+const AdminInitSpaceInfoPage = () => {
+  const location = useLocation();
+  const { placeName } = location.state || { placeName: "공간명 없음" };
+
+
+  const [selectedFilters, setSelectedFilters] = useState<Record<TabLabel, string[]>>({
+    "이용 목적": [],
+    "공간 종류": [],
+    분위기: [],
+    부가시설: [],
+    지역: [],
+  });
+
+  const toggleFilter = (category: TabLabel, label: string) => {
+    setSelectedFilters((prev) => {
+      const hasLabel = prev[category]?.includes(label);
+      const updated = hasLabel
+        ? prev[category].filter((item) => item !== label)
+        : [...(prev[category] || []), label];
+      return { ...prev, [category]: updated };
+    });
+  };
+
+  const sections = [
+    { title: "이용목적" as TabLabel, labels: ["개인공부", "그룹공부", "휴식", "노트북 작업", "집중공부"] },
+    { title: "공간종류" as TabLabel, labels: ["도서관", "카페", "민간학습공간", "공공학습공간", "교내학습공간"] },
+    { title: "분위기" as TabLabel, labels: ["넓은", "아늑한", "깔끔한", "조용한", "음악이 나오는", "이야기를 나눌 수 있는"] },
+    { title: "부가시설" as TabLabel, labels: ["Wi-Fi", "콘센트", "넓은 좌석", "음료"] },
+    { title: "지역" as TabLabel, labels: ["강남권", "강북권", "도심권", "서남권", "서북권", "동남권", "성동·광진권"] },
+  ];
+
+  return (
+    <div className="min-h-screen bg-white px-4 pt-4 pb-24">
+      <TopHeader title="새 공간 등록" />
+
+      {/* 안내 문구 */}
+      <p className="text-sm text-gray-700 text-center mt-6 mb-4">
+        공간 초기 정보를 설정해주세요.
+      </p>
+
+      {/* 장소명 */}
+      <h2 className="text-xl font-bold mb-4">{placeName}</h2>
+
+      {/* 필터 섹션 */}
+      {sections.map((section) => (
+        <FilterSection
+          key={section.title}
+          title={section.title}
+          labels={section.labels}
+          selectedFilters={selectedFilters}
+          toggleFilter={toggleFilter}
+        />
+      ))}
+
+      {/* 하단 등록 버튼 */}
+      <div className="fixed bottom-0 left-0 w-full px-4 pb-6 bg-white">
+        <button className="w-full bg-[#4cb1f1] text-white py-3 rounded-lg text-sm font-semibold">
+          등록완료
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AdminInitSpaceInfoPage;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #61

## 📝 작업 내용

- 공간 등록 플로우 UI 구성
  - `AdminCreateSpacePage` 생성  
    - 장소명 및 구글맵 링크 입력 필드 구현  
    - "공간 정보 가져오기" 버튼 클릭 시 유효성 검사 후 `/admin/confirm-space`로 이동  
    - 유효성 실패 시 실패 메시지 박스 출력 (중앙 정렬 및 스타일 적용)

  - `AdminConfirmSpacePage` 생성  
    - 상단 안내 문구 및 공간명 표시  
    - `SpaceInfoSimple` 컴포넌트 활용하여 요약 정보 표시 (예상/실시간 혼잡도 제외)  
    - "취소" 및 "확인" 버튼 하단 고정  
    - 버튼 위 불필요한 회색 선 제거  
    - "확인" 클릭 시 `/admin/init-space-info`로 이동하며 장소명 전달

  - `AdminInitSpaceInfoPage` 생성  
    - 상단 안내 문구 및 장소명 표시  
    - 공간 필터 입력 UI 구성 (`FilterSection` 재사용)  
    - 하단 "등록완료" 버튼 고정

- 기타 공통 개선
  - `FilterSection` 컴포넌트의 `sectionRef` prop을 선택 속성으로 변경하여 유연성 확보
  - `SpaceInfoSimple` 컴포넌트 분리 및 활용: 혼잡도 섹션을 제거한 단순 정보 버전


## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

