### PR TITLE
feat: 등록 공간 수정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,8 @@ import AdminRequestDetailPage from "./pages/admin/AdminRequestDetailPage";
 import AdminCreateSpacePage from "./pages/admin/AdminCreateSpacePage";
 import AdminConfirmSpacePage from "./pages/admin/AdminConfirmSpacePage";
 import AdminInitSpaceInfoPage from "./pages/admin/AdminInitSpaceInfoPage";
+import AdminSearchSpacePage from "./pages/admin/AdminSearchSpacePage";
+import AdminEditSpacePage from "./pages/admin/AdminEditSpacePage";
 
 const publicRoutes: RouteObject[] = [
   {
@@ -92,6 +94,8 @@ const protectedRoutes: RouteObject[] = [
       { path: "create-space", element: <AdminCreateSpacePage /> },
       { path: "confirm-space", element: <AdminConfirmSpacePage /> },
       { path: "init-space-info", element: <AdminInitSpaceInfoPage /> },
+      { path: "search-space", element: <AdminSearchSpacePage /> },
+      { path: "edit-space", element: <AdminEditSpacePage /> },
     ],
   },
 ];

--- a/src/components/mapSearch/PlaceSelectSheet.tsx
+++ b/src/components/mapSearch/PlaceSelectSheet.tsx
@@ -15,12 +15,16 @@ interface PlaceSelectSheetProps {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
   space: SpaceLite | null;
+  onDetail: () => void;
+  onLike: () => void;
 }
 
 const PlaceSelectSheet: React.FC<PlaceSelectSheetProps> = ({
   isOpen,
   setIsOpen,
   space,
+  onDetail,
+  onLike,
 }) => {
   return (
     <>
@@ -45,8 +49,8 @@ const PlaceSelectSheet: React.FC<PlaceSelectSheetProps> = ({
               distance={space.distance}
               tags={space.tags}
               isLiked={space.isLiked}
-              onDetail={() => alert(`${space.name} 상세보기`)}
-              onLike={() => alert(`${space.name} 좋아요 토글`)}
+              onDetail={onDetail}
+              onLike={onLike}
             />
           </div>
         </div>

--- a/src/components/space/SpaceListCard.tsx
+++ b/src/components/space/SpaceListCard.tsx
@@ -10,6 +10,7 @@ interface Props {
   onDetail: () => void;
   onLike: () => void;
   enableWholeCardClick?: boolean; // 카드 전체 클릭 허용 여부 (기본 false)
+  buttonText?: string;
 }
 
 const SpaceListCard: React.FC<Props> = ({
@@ -22,6 +23,7 @@ const SpaceListCard: React.FC<Props> = ({
   onDetail,
   onLike,
   enableWholeCardClick = false, // 기본값 false
+  buttonText,
 }) => (
   <div
     className="
@@ -89,7 +91,7 @@ const SpaceListCard: React.FC<Props> = ({
         }}
         className="block w-[140px] py-1.5 rounded-full bg-sky-400 text-white text-sm font-semibold active:bg-sky-500"
       >
-        상세보기
+        {buttonText || "상세보기"}
       </button>
     </div>
   </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -198,6 +198,8 @@ const SearchPage = () => {
           space={selectedSpace}
           isOpen={isPlaceSelectSheetOpen}
           setIsOpen={setIsPlaceSelectSheetOpen}
+          onDetail={() => alert(`${selectedSpace.name} 상세 보기`)}
+          onLike={() => alert(`${selectedSpace.name} 좋아요 토글`)}
         />
       )}
     </div>

--- a/src/pages/admin/AdminEditSpacePage.tsx
+++ b/src/pages/admin/AdminEditSpacePage.tsx
@@ -1,0 +1,93 @@
+import TopHeader from "../../components/TopHeader";
+import SpaceInfoSimple from "../../components/detail/SpaceInfoSimple";
+import dummySpaces from "../../constants/dummySpaces";
+import { useNavigate, useLocation } from "react-router-dom";
+import FilterSection from "../../components/mapSearch/FilterSection";
+import type { TabLabel } from "../../hooks/useSearchFilters";
+import { useState } from "react";
+
+const AdminEditSpacePage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const { placeName, space } = location.state || {
+    placeName: "공간명 없음",
+    space: dummySpaces[0], // fallback
+  };
+
+  const [selectedFilters, setSelectedFilters] = useState<Record<TabLabel, string[]>>({
+    "이용 목적": [],
+    "공간 종류": [],
+    분위기: [],
+    부가시설: [],
+    지역: [],
+  });
+
+  const toggleFilter = (category: TabLabel, label: string) => {
+    setSelectedFilters((prev) => {
+      const hasLabel = prev[category]?.includes(label);
+      const updated = hasLabel
+        ? prev[category].filter((item) => item !== label)
+        : [...(prev[category] || []), label];
+      return { ...prev, [category]: updated };
+    });
+  };
+
+  const sections = [
+    { title: "이용목적" as TabLabel, labels: ["개인공부", "그룹공부", "휴식", "노트북 작업", "집중공부"] },
+    { title: "공간종류" as TabLabel, labels: ["도서관", "카페", "민간학습공간", "공공학습공간", "교내학습공간"] },
+    { title: "분위기" as TabLabel, labels: ["넓은", "아늑한", "깔끔한", "조용한", "음악이 나오는", "이야기를 나눌 수 있는"] },
+    { title: "부가시설" as TabLabel, labels: ["Wi-Fi", "콘센트", "넓은 좌석", "음료"] },
+    { title: "지역" as TabLabel, labels: ["강남권", "강북권", "도심권", "서남권", "서북권", "동남권", "성동·광진권"] },
+  ];
+
+  const handleConfirm = () => {
+    navigate("/admin/search-space", {  // AdminSearchSpacePage로 이동
+      state: {
+        placeName: space.name,
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-white px-4 pt-6 pb-32 relative">
+      <TopHeader title="새 공간 등록" />
+
+      {/* 안내 문구 */}
+      <p className="mt-6 text-center text-sm text-gray-700 whitespace-pre-line mb-6">
+        공간 정보를 수정해주세요.
+      </p>
+
+      {/* 장소명 */}
+      <h2 className="text-xl font-bold mb-2">{placeName}</h2>
+
+      {/* 정보 박스 */}
+      <div className="border border-gray-300 bg-white rounded-lg p-4 mb-10">
+        <SpaceInfoSimple space={space} />
+      </div>
+
+      {/* 필터 섹션 */}
+      {sections.map((section) => (
+        <FilterSection
+          key={section.title}
+          title={section.title}
+          labels={section.labels}
+          selectedFilters={selectedFilters}
+          toggleFilter={toggleFilter}
+        />
+      ))}
+
+      {/* 하단 등록 버튼 */}
+      <div className="fixed bottom-0 left-0 w-full px-4 pb-6 bg-white">
+        <button
+          onClick={handleConfirm}
+          className="w-full bg-[#4cb1f1] text-white py-3 rounded-lg text-sm font-semibold"
+        >
+          수정하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AdminEditSpacePage;

--- a/src/pages/admin/AdminHomePage.tsx
+++ b/src/pages/admin/AdminHomePage.tsx
@@ -51,7 +51,10 @@ const AdminHomePage = () => {
               새 공간 등록
             </span>
           </button>
-          <button className="bg-white flex flex-col items-center w-28 h-28 py-8 rounded-xl shadow-sm border border-[#E7EDF3] transition">
+          <button
+            onClick={() => navigate("/admin/search-space")}
+            className="bg-white flex flex-col items-center w-28 h-28 py-8 rounded-xl shadow-sm border border-[#E7EDF3] transition"
+          >
             <FaClock className="text-[#737373] mb-1" size={24} />
             <span className="text-sm text-[#737373] font-semibold">
               등록 공간 수정

--- a/src/pages/admin/AdminSearchSpacePage.tsx
+++ b/src/pages/admin/AdminSearchSpacePage.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { FaSearch } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import TopHeader from "../../components/TopHeader";
+import SpaceListCard from "../../components/space/SpaceListCard";
+import dummySpaces from "../../constants/dummySpaces";
+
+// SpaceLite 타입 직접 선언
+interface SpaceLite {
+  id: number;
+  name: string;
+  image: string;
+  rating: number;
+  distance: number;
+  tags: string[];
+  isLiked: boolean;
+}
+
+const AdminSearchSpacePage = () => {
+  const [searchInput, setSearchInput] = useState("");
+  const [_, setSelectedSpace] = useState<SpaceLite | null>(null);
+  const navigate = useNavigate();
+
+  const handleSearch = () => {
+    const result = dummySpaces.find((space) =>
+      space.name.includes(searchInput)
+    );
+    if (result) {
+      setSelectedSpace(result);
+    } else {
+      setSelectedSpace(null);
+    }
+  };
+
+  const handleDetail = (space: SpaceLite) => {
+    navigate("/admin/edit-space", {
+      state: { placeName: space.name, space }, // 공간 정보 함께 전달
+    });
+  };
+
+  const handleLike = (space: SpaceLite) => {
+    alert(`${space.name} 좋아요 토글`);
+    // 좋아요 토글 로직 추가 예정
+  };
+
+  const filteredSpaces = searchInput
+    ? dummySpaces.filter((space) => space.name.includes(searchInput))
+    : [];
+
+  return (
+    <div className="min-h-screen bg-white px-4 pt-4 pb-24">
+      <TopHeader title="등록 공간 수정" />
+
+      {/* 검색창 */}
+      <div className="mt-4 mb-4">
+        <div className="relative">
+          <FaSearch className="absolute top-1/2 left-3 transform -translate-y-1/2 text-gray-500" />
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSearch();
+            }}
+            placeholder="수정할 공간을 검색하세요."
+            className="w-full pl-10 pr-4 py-2 rounded-md border border-gray-300  focus:ring-0 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* 검색 결과 리스트 */}
+      {searchInput !== "" && filteredSpaces.length > 0 && (
+        <div className="px-4 pt-2">
+          {filteredSpaces.map((space) => (
+            <SpaceListCard
+              key={space.id}
+              name={space.name}
+              image={space.image}
+              rating={space.rating}
+              distance={space.distance}
+              tags={space.tags}
+              isLiked={space.isLiked}
+              onDetail={() => handleDetail(space)}
+              onLike={() => handleLike(space)}
+              enableWholeCardClick={false}
+              buttonText="수정하기"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminSearchSpacePage;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #63 

## 작업 내용

- `AdminSearchSpacePage` 페이지 구현  
  - 공간명으로 기존 등록 공간 검색 가능  
  - 검색 결과 리스트에서 '수정하기' 버튼 클릭 시 해당 공간 정보를 `state`로 전달하며 상세 수정 페이지로 이동

- `AdminEditSpacePage` 페이지 구현  
  - 전달받은 공간 정보를 확인하고 필터 정보 수정 가능  
  - `FilterSection` 재활용하여 초기 필터 구성 구현  
  - '수정하기' 버튼 클릭 시 `AdminSearchSpacePage`로 이동 처리

- `SpaceListCard` 컴포넌트 확장  
  - 버튼 텍스트를 props(`buttonText`)로 받아 유연하게 사용  
  - 카드 전체 클릭 가능 여부를 `enableWholeCardClick` props로 제어 가능하도록 수정

- UI 개선  
  - 검색창 클릭 시 테두리 색 변화 제거 (`focus:outline-none`, `focus:ring-0`)  
  - 검색어 미입력 및 검색 결과 없을 때 모두 깨끗한 흰 배경 유지


## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

