### PR TITLE
 feat: 검색결과 시트 ui 수정

### DIFF
--- a/src/components/mapsearch/BottomSheet.tsx
+++ b/src/components/mapsearch/BottomSheet.tsx
@@ -74,7 +74,7 @@ const BottomSheet = ({
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
-      <div className="w-10 h-1 bg-gray-400 rounded-full mx-auto mt-2 cursor-pointer" />
+      <div className="w-[30px] h-[3px] bg-gray-400 rounded-full mx-auto mt-2 cursor-pointer" />
 
       {!isSheetOpen && (
         <>
@@ -84,11 +84,12 @@ const BottomSheet = ({
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
           />
-          <TabButtons
-            selectedFilters={selectedFilters}
-            onClick={() => setIsSheetOpen(true)}
-          />
-
+          <div className="pl-[9px] pr-0">
+            <TabButtons
+              selectedFilters={selectedFilters}
+              onClick={() => setIsSheetOpen(true)}
+            />
+          </div>
         </>
       )}
 

--- a/src/components/mapsearch/PlaceSelectSheet.tsx
+++ b/src/components/mapsearch/PlaceSelectSheet.tsx
@@ -31,16 +31,16 @@ const PlaceSelectSheet: React.FC<PlaceSelectSheetProps> = ({
       {isOpen && space && (
         <div
           className="fixed bottom-0 left-0 w-full bg-white rounded-t-2xl shadow-lg z-30 transition-transform duration-300"
-          style={{ height: "230px" }} // ← 필요 시 높이 조절
+          style={{ height: "240px" }} // ← 필요 시 높이 조절
           onClick={() => setIsOpen(false)} // 임시 동작, 실제 버튼으로 교체 가능
         >
           {/* 손잡이만 있는 헤더 */}
           <div className="select-none touch-none">
-            <div className="w-10 h-1 bg-gray-400 rounded-full mx-auto mt-2 cursor-pointer" />
+            <div className="w-[30px] h-[3px] bg-gray-400 rounded-full mx-auto mt-2 cursor-pointer" />
           </div>
 
           {/* 공간 정보 하나만 표시 */}
-          <div className="px-4 pt-4">
+          <div className="px-4">
             <SpaceListCard
               key={space.id}
               name={space.name}

--- a/src/components/mapsearch/SearchResultSheet.tsx
+++ b/src/components/mapsearch/SearchResultSheet.tsx
@@ -69,17 +69,20 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
         >
           {/* 손잡이 + 탭버튼 드래그 구간 */}
           <div
-            className="select-none touch-none"
+            className="select-none touch-none pt-[8px]"
             onMouseDown={handleStart}
             onTouchStart={handleStart}
           >
             {/* 손잡이 */}
-            <div className="w-10 h-1 bg-gray-400 rounded-full mx-auto mt-2 cursor-pointer" />
+            <div className="w-[30px] h-[3px] bg-gray-400 rounded-full mx-auto cursor-pointer" />
 
             {/* 탭 버튼 */}
-            <div className="py-2 px-0.5 overflow-x-hidden">
+            <div className="mt-[1px] pb-0 pr-0 overflow-x-hidden" style={{ paddingLeft: "13px" }}>
               <TabButtons selectedFilters={selectedFilters} onClick={() => setIsOpen(true)} />
             </div>
+
+            {/* 구분선 추가 */}
+            <div className="h-px bg-gray-200" />
           </div>
 
           {/* 공간 목록 */}

--- a/src/components/mapsearch/TabButtons.tsx
+++ b/src/components/mapsearch/TabButtons.tsx
@@ -9,7 +9,7 @@ const TabButtons = ({ onClick, selectedFilters }: TabButtonsProps) => {
   const tabs: TabLabel[] = ["이용 목적", "공간 종류", "분위기", "부가시설", "지역"];
 
   return (
-    <div className="flex justify-center gap-2 overflow-x-auto px-2 pt-3 pb-2">
+    <div className="flex justify-start gap-2 overflow-x-auto px-2 pt-3 pb-2">
       {tabs.map((tab) => {
         const selections = selectedFilters[tab] || [];
         let label: string;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> #65 

## 📝 작업 내용

- 검색 결과 시트(SearchResultSheet)의 UI 개선
  - 손잡이 위치를 시트 상단에서 정확히 8px 아래로 고정
  - 탭 버튼(TabButtons)을 손잡이와 10px 간격으로 배치
  - 탭 버튼 아래에 회색 구분선 추가 및 간격 조정
  - 탭 버튼 좌측 여백을 정확히 13px로 설정 (style 속성 활용)
  - TabButtons 내부 정렬을 justify-center → justify-start로 수정하여 왼쪽 정렬 구현

- 장소 선택 시트(PlaceSelectSheet) UI 개선
  - 손잡이 위치는 유지하면서 공간 정보 영역을 최대한 손잡이와 붙도록 조정 (pt-1.5 → pt-0.5)

- 필터 시트(BottomSheet) 닫힌 상태에서의 탭 버튼 좌측 정렬 적용
  - 닫힌 상태에서도 TabButtons를 13px 여백으로 왼쪽 정렬되도록 래퍼 div에 `pl-[13px]` 적용

## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

