### PR TITLE
feat: 공간 검색 api 연결 및 최근 검색어 오류 수정

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -12,7 +12,7 @@ axiosInstance.interceptors.request.use(
         if (accessToken) {
             config.headers = config.headers || {};
             config.headers.Authorization = `Bearer ${accessToken}`;
-            
+            config.headers.accessToken = accessToken; 
         }
 
         return config;

--- a/src/apis/placeSearch.ts
+++ b/src/apis/placeSearch.ts
@@ -1,9 +1,9 @@
 import { axiosInstance } from "./axios";
 
-interface PlaceItem {
+export interface PlaceItem {
   placeId: number;
   name: string;
-  rating: number;
+  rating: number | null;
   hashtag: string;
   imageUrl: string;
   isLike: boolean;

--- a/src/components/mapsearch/SearchResultSheet.tsx
+++ b/src/components/mapsearch/SearchResultSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import SpaceListCard from "../space/SpaceListCard";
-import dummySpaces from "../../constants/dummySpaces";
+import type { PlaceItem } from "../../apis/placeSearch";
 import type { TabLabel } from "../../hooks/useSearchFilters";
 import TabButtons from "./TabButtons";
 import type { Space } from "../../types/space";
@@ -13,6 +13,7 @@ interface SearchResultSheetProps {
   selectedFilters: Record<TabLabel, string[]>;
   setSelectedSpace: (space: Space) => void;
   setIsPlaceSelectSheetOpen: (open: boolean) => void;
+  places: PlaceItem[];
 }
 
 const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
@@ -23,7 +24,18 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
   selectedFilters,
   setSelectedSpace,
   setIsPlaceSelectSheetOpen,
+  places,
 }) => {
+  const toCard = (p: PlaceItem) => ({
+    id: p.placeId,
+    name: p.name,
+    image: p.imageUrl,
+    rating: p.rating ?? 0,         // null 방어
+    distance: 0,                   // TODO: 서버 연결되면 교체
+    tags: p.hashtag ? [p.hashtag] : [],
+    isLiked: !!p.isLike,
+  });
+  
   const startYRef = useRef(0);
   const startHeightRef = useRef(0);
 
@@ -88,7 +100,9 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
           {/* 공간 목록 */}
           <div className="h-full overflow-y-auto pb-24">
             <div className="px-4">
-              {dummySpaces.map((space) => (
+              {places.map((p) => {
+                const space = toCard(p);
+                return (
                 <SpaceListCard
                   key={space.id}
                   name={space.name}
@@ -115,7 +129,7 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
                   }}
                 />
 
-              ))}
+              );})}
 
             </div>
           </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -10,6 +10,7 @@ import { useSearchMode } from "../contexts/SearchModeContext";
 import type { Space } from "../types/space";
 import PlaceSelectSheet from "../components/mapsearch/PlaceSelectSheet";
 import { searchPlaces } from "../apis/placeSearch";
+import type { PlaceItem } from "../apis/placeSearch";
 
 const SearchPage = () => {
   useEffect(() => {
@@ -91,9 +92,21 @@ const SearchPage = () => {
   };
 
   const handleRecentClick = (keyword: string) => {
-    setSearchInput(keyword);                 // 검색창에 키워드 반영
-    setIsSearchResultSheetOpen(true);       // 검색 결과 시트 열기
-  };
+    setSearchInput(keyword); // 입력창 반영
+    void (async () => {
+     const result = await searchPlaces({
+       keyword,
+       purpose: selectedFilters["이용 목적"]?.[0],
+       type: selectedFilters["공간 종류"]?.[0],
+       mood: selectedFilters["분위기"]?.[0],
+       facilities: selectedFilters["부가시설"]?.[0],
+       location: selectedFilters["지역"]?.[0],
+       page: 0,
+     });
+     setPlaces(result);                 // 결과 반영
+     setIsSearchResultSheetOpen(true); // 시트 열기
+   })();
+ };
 
   const [currentLocation, setCurrentLocation] = useState<{ lat: number; lng: number } | null>(null);
 
@@ -117,20 +130,7 @@ const SearchPage = () => {
   
   const mapRef = useRef<{ recenterToCurrentLocation: () => void }>(null);
 
-  const fetchSearchResults = async () => {
-    const result = await searchPlaces({
-      keyword: searchInput.trim(),
-      purpose: selectedFilters["이용 목적"]?.[0],
-      type: selectedFilters["공간 종류"]?.[0],
-      mood: selectedFilters["분위기"]?.[0],
-      facilities: selectedFilters["부가시설"]?.[0],
-      location: selectedFilters["지역"]?.[0],
-      page: 0,
-    });
-
-    console.log("검색 결과:", result);
-    // setSearchResults(result); // 상태에 저장하여 화면에 표시
-  };
+  const [places, setPlaces] = useState<PlaceItem[]>([]);
 
 
   return (
@@ -151,9 +151,9 @@ const SearchPage = () => {
           searchInput={searchInput}
           setSearchInput={setSearchInput}
           openSearchResultSheet={() => {
-            fetchSearchResults(); // 이미 SearchPage에 있는 함수
             setIsSearchResultSheetOpen(true);
           }}
+          setPlaceResults={setPlaces}
           isSearchMode={isSearchMode}
           isSearchResultSheetOpen={isSearchResultSheetOpen}
           enterSearchMode={enterSearchMode}
@@ -239,6 +239,7 @@ const SearchPage = () => {
         selectedFilters={selectedFilters}
         setSelectedSpace={setSelectedSpace}
         setIsPlaceSelectSheetOpen={setIsPlaceSelectSheetOpen}
+        places={places}  
       />
 
       {isPlaceSelectSheetOpen && selectedSpace && (


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #80 

## 📝 작업 내용

- 공간 검색 API 연동: dummySpaces 제거, places 상태로 렌더

- PlaceItem 타입 export, SearchResultSheet에 places prop 추가

- SearchMode가 setPlaceResults(result)로 검색 결과 전달(중복 fetch 제거)

- 최근 검색어 최대 3개만 표시 (cap3)

- 삭제 시 재조회로 백필 금지(화면 상태만 감소, 유지)

- Enter 검색 후 최근 검색어는 새 키워드만 머지해 갱신

- 최근 검색어 클릭 시 즉시 검색 + 결과 시트 오픈

- 삭제 API를 **DELETE /recent-search/{id}**로 고정(백엔드 id 응답 사용)

## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

