### PR TITLE
feat: 공간 검색 결과 시트 ui 수정

### DIFF
--- a/src/components/mapsearch/SearchResultSheet.tsx
+++ b/src/components/mapsearch/SearchResultSheet.tsx
@@ -89,7 +89,7 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
             <div className="w-[30px] h-[3px] bg-gray-400 rounded-full mx-auto cursor-pointer" />
 
             {/* 탭 버튼 */}
-            <div className="mt-[1px] pb-0 pr-0 overflow-x-hidden" style={{ paddingLeft: "13px" }}>
+            <div className="mt-[1px] pb-0 pr-0 overflow-x-hidden" style={{ paddingLeft: "7px" }}>
               <TabButtons selectedFilters={selectedFilters} onClick={() => setIsOpen(true)} />
             </div>
 
@@ -98,7 +98,7 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
           </div>
 
           {/* 공간 목록 */}
-          <div className="h-full overflow-y-auto pb-24">
+          <div className="h-full overflow-y-auto pb-36">
             <div className="px-4">
               {places.map((p) => {
                 const space = toCard(p);

--- a/src/components/mapsearch/TabButtons.tsx
+++ b/src/components/mapsearch/TabButtons.tsx
@@ -31,7 +31,7 @@ const TabButtons = ({ onClick, selectedFilters }: TabButtonsProps) => {
             key={tab}
             onClick={onClick}
             style={{ borderStyle: "solid" }}
-            className={`flex items-center px-2 py-1 text-xs rounded-full border whitespace-nowrap flex-shrink-0
+            className={`flex items-center px-3 py-1 text-[10px] leading-4 rounded-full border whitespace-nowrap flex-shrink-0
               ${isSelected
                 ? "bg-[#eff7fb] text-[#4cb1f1] border-[#4cb1f1]"
                 : "bg-white text-gray-400 border-gray-300"}

--- a/src/components/space/SpaceListCard.tsx
+++ b/src/components/space/SpaceListCard.tsx
@@ -66,54 +66,50 @@ const SpaceListCard: React.FC<Props> = ({
   }, [distanceProp, location, myLocation.coordinates, myLocation.loaded, name]);
   
   return (
-    <div
-      className="
-        flex items-center relative
-        border-b border-[#CCCCCC]
-        pr-[30px] pl-[20px] py-5
-      "
-    >
-      <div className="relative w-[180px] h-[130px] flex-shrink-0 mr-4">
-        <img src={image} alt={name} className="w-full h-full object-cover rounded-xl border border-[#E5ECF2]" />
-        <button
-          className="absolute top-2 right-2 z-10"
-          onClick={(e) => { e.stopPropagation(); onLike(); }}
-          aria-label="좋아요"
-          style={{ lineHeight: 0, background: "none", border: "none" }}
-        >
-          <img
-            src={heartIcon}
-            alt="좋아요 아이콘"
-            width={25}
-            height={25}
-            style={{ filter: isLiked ? "none" : "grayscale(100%) brightness(1.5)" }}
-            className="transition-transform duration-150 active:scale-90"
-          />
-        </button>
-      </div>
+    <div className="-mx-4 border-b border-[#CCCCCC]">
+      <div className="flex items-center relative pr-[30px] pl-[20px] py-5">
+        <div className="relative w-[180px] h-[130px] flex-shrink-0 mr-4">
+          <img src={image} alt={name} className="w-full h-full object-cover rounded-xl border border-[#E5ECF2]" />
+          <button
+            className="absolute top-2 right-2 z-10"
+            onClick={(e) => { e.stopPropagation(); onLike(); }}
+            aria-label="좋아요"
+            style={{ lineHeight: 0, background: "none", border: "none" }}
+          >
+            <img
+              src={heartIcon}
+              alt="좋아요 아이콘"
+              width={25}
+              height={25}
+              style={{ filter: isLiked ? "none" : "grayscale(100%) brightness(1.5)" }}
+              className="transition-transform duration-150 active:scale-90"
+            />
+          </button>
+        </div>
 
-      <div className="flex-1 min-w-0 flex flex-col justify-center">
-        <div className="font-semibold text-lg text-[#222] truncate mb-2">{name}</div>
-        <div className="flex items-center text-[15px]">
-          <span className="flex items-center">
-            <svg width={12} height={12} viewBox="0 0 20 20" fill="#FFFFFF" stroke="#000000" strokeWidth="1" className="inline">
-              <path d="M10 15.272l-5.708 3.11 1.09-6.365L.764 7.982l6.383-.927L10 1.018l2.853 6.037 6.383.927-4.618 4.035 1.09 6.365z" />
-            </svg>
-            <span className="font-medium ml-2 text-[13px]">{rating}</span>
-          </span>
+        <div className="flex-1 min-w-0 flex flex-col justify-center">
+          <div className="font-semibold text-lg text-[#222] truncate mb-2">{name}</div>
+          <div className="flex items-center text-[15px]">
+            <span className="flex items-center">
+              <svg width={12} height={12} viewBox="0 0 20 20" fill="#FFFFFF" stroke="#000000" strokeWidth="1" className="inline">
+                <path d="M10 15.272l-5.708 3.11 1.09-6.365L.764 7.982l6.383-.927L10 1.018l2.853 6.037 6.383.927-4.618 4.035 1.09 6.365z" />
+              </svg>
+              <span className="font-medium ml-2 text-[13px]">{rating}</span>
+            </span>
+          </div>
+          <div>
+            <span className="text-[#000000] text-[13px]">
+              {distanceText}
+            </span>
+          </div>
+          <div className="text-[13px] text-gray-500 truncate mb-2">{tags.join(" ")}</div>
+          <button
+            onClick={(e) => { e.stopPropagation(); onDetail(); }}
+            className="block w-[140px] py-1 rounded-full bg-[#4CB1F1] text-white text-[13px] font-semibold active:bg-sky-500"
+          >
+            {buttonText || "상세보기"}
+          </button>
         </div>
-        <div>
-          <span className="text-[#000000] text-[13px]">
-            {distanceText}
-          </span>
-        </div>
-        <div className="text-[13px] text-gray-500 truncate mb-2">{tags.join(" ")}</div>
-        <button
-          onClick={(e) => { e.stopPropagation(); onDetail(); }}
-          className="block w-[140px] py-1 rounded-full bg-[#4CB1F1] text-white text-[13px] font-semibold active:bg-sky-500"
-        >
-          {buttonText || "상세보기"}
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #107 

## 📝 작업 내용

- 탭버튼 글자 text-[10px]+leading-4
- 검색 결과 시트 하단 여백 확대(pb-36/40+safe-area)
- 장소 리스트 구분선 full-bleed(divide-y+mx-[-16px])

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [x] 변경 사항에 대한 테스트를 진행했습니다.

