### PR TITLE
feat: 관리자 새 공간 등록 및 등록 공간 수정 api 연결

### DIFF
--- a/src/pages/admin/AdminConfirmSpacePage.tsx
+++ b/src/pages/admin/AdminConfirmSpacePage.tsx
@@ -1,35 +1,91 @@
+// src/pages/admin/AdminConfirmSpacePage.tsx
 import TopHeader from "../../components/TopHeader";
 import SpaceInfoSimple from "../../components/detail/SpaceInfoSimple";
 import dummySpaces from "../../constants/dummySpaces";
 import type { Space } from "../../constants/dummySpaces";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { loadKakaoScript } from "../../utils/kakaoMapLoader"; // ✅ 카카오 스크립트 로더만 사용
+
+declare global {
+  interface Window { kakao: any; }
+}
 
 const AdminConfirmSpacePage = () => {
   const navigate = useNavigate();
+  const { state } = useLocation() as { state?: { placeName?: string } };
+  const initialName = state?.placeName?.trim() ?? "";
 
-  // 예시: 첫 번째 공간 데이터 사용
-  const space: Space = dummySpaces[0];
+  // UI는 유지하고, 데이터만 더미→실데이터로 치환
+  const [space, setSpace] = useState<Space>(dummySpaces[0]);
 
+  // 카카오 장소검색 → UI Space로 매핑
+  const toUISpaceFromKakao = (k: any): Space => {
+    const base = dummySpaces[0]; // 누락 필드는 더미가 채움 (UI 타입 보장)
+    return {
+      ...base,
+      id: Number(k.id ?? base.id),
+      name: k.place_name ?? base.name,
+      // Kakao 검색결과에는 대표사진이 없음 → 더미 유지(또는 플레이스 썸네일 로직 추가 가능)
+      image: base.image,
+      rating: base.rating,
+      distance: base.distance,
+      tags: base.tags,
+      isLiked: base.isLiked,
+
+      // 상세정보 필드 매핑
+      address: k.road_address_name || k.address_name || base.address,
+      phone: k.phone || base.phone,
+      opening: base.opening,       // 카카오는 영업시간 미제공 → 더미 유지
+      closedDays: base.closedDays, // 필요 시 별도 입력 단계에서 수정
+      isFree: base.isFree,
+    };
+  };
+
+  useEffect(() => {
+    if (!initialName) return;
+
+    (async () => {
+      try {
+        await loadKakaoScript(); // services 로드 필수
+        const ps = new window.kakao.maps.services.Places();
+
+        ps.keywordSearch(initialName, (data: any[], status: any) => {
+          if (status !== window.kakao.maps.services.Status.OK || !data?.length) return;
+
+          // 공백 무시 정확매칭 우선, 없으면 첫 번째
+          const norm = (s: string) => s.replace(/\s/g, "");
+          const hit = data.find(d => norm(d.place_name) === norm(initialName)) ?? data[0];
+
+          setSpace(toUISpaceFromKakao(hit));
+        });
+      } catch (e) {
+        console.warn("카카오 장소검색 실패:", e);
+        // 실패 시 더미 유지 (UI 변경 없음)
+      }
+    })();
+  }, [initialName]);
+
+  // handleConfirm 수정
   const handleConfirm = () => {
     navigate("/admin/init-space-info", {
       state: {
         placeName: space.name,
+        spaceFromKakao: space,   // 카카오에서 매핑한 공간 데이터 함께 전달
       },
     });
   };
 
+
   return (
     <div className="min-h-screen bg-white">
-      {/* 상단 헤더 */}
       <TopHeader title="새 공간 등록" />
 
-      {/* 안내 문구 */}
       <p className="w-[224px] h-[28px] absolute top-[66px] left-1/2 -translate-x-1/2 text-md text-black text-center opacity-100">
         이 공간 정보를 등록하시겠습니까?
         {"\n"}확인 후 진행해주세요.
       </p>
 
-      {/* 정보 박스 */}
       <div className="w-full px-[15px] pt-[100px] flex flex-col items-center">
         <div className="w-[344px] flex flex-col gap-[10px]">
           <h2 className="text-xl font-bold">{space.name}</h2>
@@ -39,7 +95,6 @@ const AdminConfirmSpacePage = () => {
         </div>
       </div>
 
-      {/* 하단 버튼 */}
       <div className="fixed bottom-[20px] left-1/2 -translate-x-1/2 w-[334px] h-[45px] bg-white flex justify-between gap-[6px]">
         <button
           onClick={() => navigate(-1)}

--- a/src/pages/admin/AdminCreateSpacePage.tsx
+++ b/src/pages/admin/AdminCreateSpacePage.tsx
@@ -16,35 +16,49 @@ const AdminCreateSpacePage = () => {
   const [googleMapsLink, setGoogleMapsLink] = useState(initialGoogleMapsLink);
   const [isValidationFailed, setIsValidationFailed] = useState(false);
 
-  const handleFetchInfo = () => {
-    // 항상 성공 처리 (이 부분은 원래 주석 처리된 로직으로 되돌릴 수 있습니다)
-    // setIsValidationFailed(false);
+  // const handleFetchInfo = () => {
+  //   // 항상 성공 처리 (이 부분은 원래 주석 처리된 로직으로 되돌릴 수 있습니다)
+  //   // setIsValidationFailed(false);
 
-    // navigate("/admin/confirm-space", {
-    //   state: {
-    //     placeName,
-    //     googleMapsLink,
-    //   },
-    // });
+  //   // navigate("/admin/confirm-space", {
+  //   //   state: {
+  //   //     placeName,
+  //   //     googleMapsLink,
+  //   //   },
+  //   // });
     
-    // 원래 있던 유효성 검사 로직입니다.
-    const normalizedPlaceName = placeName.trim().toLowerCase();
-    const normalizedLink = googleMapsLink.trim().toLowerCase();
+  //   // 원래 있던 유효성 검사 로직입니다.
+  //   const normalizedPlaceName = placeName.trim().toLowerCase();
+  //   const normalizedLink = googleMapsLink.trim().toLowerCase();
 
-    if (!normalizedLink.includes(normalizedPlaceName) || !normalizedPlaceName) {
+  //   if (!normalizedLink.includes(normalizedPlaceName) || !normalizedPlaceName) {
+  //     setIsValidationFailed(true);
+  //   } else {
+  //     setIsValidationFailed(false);
+
+  //     // 성공 시 확인 페이지로 이동 + state로 정보 전달
+  //     navigate("/admin/confirm-space", {
+  //       state: {
+  //         placeName,
+  //         googleMapsLink,
+  //       },
+  //     });
+  //   }
+  // };
+
+  const handleFetchInfo = () => {
+    const nameOk = !!placeName.trim();
+    const linkOk = !!googleMapsLink.trim();
+
+    if (!nameOk || !linkOk) {
       setIsValidationFailed(true);
-    } else {
-      setIsValidationFailed(false);
-
-      // 성공 시 확인 페이지로 이동 + state로 정보 전달
-      navigate("/admin/confirm-space", {
-        state: {
-          placeName,
-          googleMapsLink,
-        },
-      });
+      return;
     }
+
+    setIsValidationFailed(false);
+    navigate("/admin/confirm-space", { state: { placeName, googleMapsLink } });
   };
+
 
   return (
     <div className="min-h-screen bg-white">

--- a/src/pages/admin/AdminInitSpaceInfoPage.tsx
+++ b/src/pages/admin/AdminInitSpaceInfoPage.tsx
@@ -6,7 +6,8 @@ import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 const AdminInitSpaceInfoPage = () => {
-  const location = useLocation();
+  const location = useLocation() as { state?: { placeName?: string; spaceFromKakao?: any } };
+  const spaceFromKakao = location.state?.spaceFromKakao;
   const navigate = useNavigate();
   const { placeName } = location.state || { placeName: "공간명 없음" };
 
@@ -36,10 +37,18 @@ const AdminInitSpaceInfoPage = () => {
     { title: "지역" as TabLabel, labels: ["강남권", "강북권", "도심권", "서남권", "서북권", "동남권", "성동·광진권"] },
   ];
 
+  // 등록완료 핸들러에서 localStorage에 저장
   const handleComplete = () => {
-    navigate("/admin/all-requests", {
-      state: { defaultTab: "reviewed" },
-    });
+    if (spaceFromKakao) {
+      localStorage.setItem(
+        "admin:newSpaceDraft",
+        JSON.stringify({
+          space: spaceFromKakao,         // 카카오에서 받은 공간
+          filters: selectedFilters,      // 이 페이지에서 고른 필터들
+        })
+      );
+    }
+    navigate("/admin/all-requests", { state: { defaultTab: "reviewed" } });
   };
 
   return (


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #116 

## 📝 작업 내용

<h3>관리자 플로우 요약</h3>
<ol>
  <li><strong>새 공간 등록</strong>: 장소명/구글맵 링크 모두 입력 시 버튼 활성화 → 카카오맵으로 장소명 검색해 기본 정보 표시. “확인” → 초기 정보 설정으로 이동.</li>
  <li><strong>초기 정보 설정(필터)</strong>: 이용목적/공간종류/분위기/부가시설/지역 필터 선택값을 localStorage 드래프트(<code>admin:spaceDraft:&lt;placeKey&gt;</code>)로 저장. “등록완료” → 요청 목록 이동.</li>
  <li><strong>등록 공간 수정</strong>: 관리자 검색 결과에서 “수정하기” 진입 시 드래프트의 기존 필터 자동 로드 → 수정 후 “수정하기”로 덮어쓰기 저장.</li>
  <li><strong>데이터 전달</strong>: 페이지 간 이동은 <code>navigate(..., { state })</code>로 장소명·공간정보·필터 전달, 새로고침 시에도 드래프트로 복원.</li>
</ol>


## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

