### PR TITLE
fix: 검색결과 상세보기 후 뒤로가기 버튼 에러 해결

### DIFF
--- a/src/components/mapsearch/SearchMode.tsx
+++ b/src/components/mapsearch/SearchMode.tsx
@@ -79,6 +79,8 @@ const SearchMode = ({
         console.log("🔍 검색 결과:", result); // 추후에 상태로 set 가능
         setPlaceResults(result);      // 검색 결과 상태 전달
 
+        try { sessionStorage.removeItem("searchResultsResetAt:v1"); } catch {}
+
         // 검색 직후 재조회하되, 새 키워드만 반영하고 기존 화면 항목만 유지(백필 차단)
         const server = await getRecentSearches();
         setRecentSearches((prev) => {

--- a/src/components/mapsearch/SearchResultSheet.tsx
+++ b/src/components/mapsearch/SearchResultSheet.tsx
@@ -8,6 +8,10 @@ import TabButtons from "./TabButtons";
 import type { Space } from "../../types/space";
 import { useLikeSpace } from "../../hooks/useLikeSpace";
 
+const CACHE_KEY_RESULTS = "searchResultsCache:v1";
+const CACHE_KEY_SCROLL = "searchResultsScrollTop:v1";
+const CACHE_KEY_RESET = "searchResultsResetAt:v1";
+
 interface SearchResultSheetProps {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
@@ -34,22 +38,117 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
 
   const [placeList, setPlaceList] = useState<PlaceItem[]>(places);
 
+  // 목록 스크롤 컨테이너 ref
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  // 안전한 세션스토리지 헬퍼
+  type ResultsCacheShape = { savedAt: number; data: PlaceItem[] };
+
+  const saveCache = (placesData: PlaceItem[]) => {
+    try {
+      const payload: ResultsCacheShape = { savedAt: Date.now(), data: placesData };
+      sessionStorage.setItem(CACHE_KEY_RESULTS, JSON.stringify(payload));
+    } catch {}
+  };
+
+  const loadCache = (): ResultsCacheShape | null => {
+    try {
+      const raw = sessionStorage.getItem(CACHE_KEY_RESULTS);
+      if (!raw) return null;
+      const obj = JSON.parse(raw) as ResultsCacheShape | PlaceItem[];
+      // 하위호환: 과거 구조(배열)도 허용
+      if (Array.isArray(obj)) return { savedAt: 0, data: obj };
+      return obj as ResultsCacheShape;
+    } catch {
+      return null;
+    }
+  };
+
+
+  const saveScroll = () => {
+    try {
+      if (listRef.current) {
+        sessionStorage.setItem(CACHE_KEY_SCROLL, String(listRef.current.scrollTop));
+      }
+    } catch {}
+  };
+
+  const restoreScroll = () => {
+    try {
+      const v = sessionStorage.getItem(CACHE_KEY_SCROLL);
+      if (v && listRef.current) {
+        listRef.current.scrollTop = Number(v) || 0;
+      }
+    } catch {}
+  };
+
+  // props 변경 시 동기화: "비어 있지 않을 때만" 덮어쓰기 + 캐시 갱신
   useEffect(() => {
-    setPlaceList(places);
+    if (places && places.length > 0) {
+      setPlaceList(places);
+      saveCache(places);
+      return;
+    }
+
+    if ((!places || places.length === 0) && placeList.length === 0) {
+      // 리셋 마커 확인
+      let resetAt = 0;
+      try {
+        const ra = sessionStorage.getItem(CACHE_KEY_RESET);
+        // 파일 상단에 추가: const CACHE_KEY_RESET = "searchResultsResetAt:v1";
+        resetAt = ra ? Number(ra) : 0;
+      } catch {}
+
+      const cached = loadCache();
+      if (cached && cached.data.length > 0) {
+        // ★ 리셋 이후 저장된 캐시만 복원 (savedAt > resetAt)
+        if (cached.savedAt > resetAt) {
+          setPlaceList(cached.data);
+        } else {
+          // 리셋 이전 캐시는 버린다
+          setPlaceList([]); // 명시적으로 비워 UI 오동작 방지
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [places]);
 
+
+  // placeList가 바뀔 때마다 캐시 갱신 (좋아요 토글 등 반영)
+  useEffect(() => {
+    if (placeList && placeList.length > 0) {
+      saveCache(placeList);
+    }
+  }, [placeList]);
+
+  // 시트가 열릴 때 복원
+  useEffect(() => {
+    if (isOpen) restoreScroll();
+    // 시트가 닫힐 때는 별도 동작 없음
+  }, [isOpen]);
+
   const handleLike = (placeId: number) => {
-    setPlaceList(currentPlaces =>
-      currentPlaces.map(p =>
+    setPlaceList(currentPlaces => {
+      const next = currentPlaces.map(p =>
         p.placeId === placeId ? { ...p, isLike: !p.isLike } : p
-      )
-    );
+      );
+      saveCache(next);
+      return next;
+    });
 
     const currentPlace = placeList.find(p => p.placeId === placeId);
     if (currentPlace) {
       toggleLike({ placeId: String(placeId), isLiked: currentPlace.isLike });
     }
   };
+
+  const goDetail = (spaceId: number) => {
+    // 현재 결과 & 스크롤 위치 저장
+    saveCache(placeList);
+    saveScroll();
+    navigate(`/space/${spaceId}`);
+  };
+
 
   // ▼▼▼ toCard 함수를 수정합니다 ▼▼▼
   const toCard = (p: PlaceItem) => ({
@@ -126,7 +225,7 @@ const SearchResultSheet: React.FC<SearchResultSheetProps> = ({
                     location={space.location} 
                     tags={space.tags}
                     isLiked={space.isLiked}
-                    onDetail={() => navigate(`/space/${space.id}`)}
+                    onDetail={() => goDetail(space.id)}
                     onLike={() => handleLike(space.id)}
                   />
                 );})}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #128 

## 📝 작업 내용

> 검색결과에서 장소 상세보기 이후 뒤로가기 버튼을 누르면 빈 검색결과 시트가 나오는 에러를 해결함.

## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

