### PR TITLE
feat: 공간 정보 수정 오류 해결

### DIFF
--- a/src/pages/admin/AdminEditSpacePage.tsx
+++ b/src/pages/admin/AdminEditSpacePage.tsx
@@ -39,7 +39,9 @@ const toServerLabel = (s: string) => {
 const toUiLabel = (s: string) => {
   if (s === "WiFi") return "Wi-Fi";
   if (s === "노트북작업") return "노트북 작업";
-  return s;
+
+  // 서버에서 받은 모든 언더바('_')를 띄어쓰기(' ')로 복구
+  return s.replace(/_/g, ' ');
 };
 
 
@@ -90,16 +92,7 @@ const AdminEditSpacePage = () => {
 
       setDetails(res);
 
-      // (변경) 라우터 state가 '실제로 선택값이 있을 때만' 사용
-      const fromState = location.state?.selectedFilters;
-      const hasAny =
-        !!fromState &&
-        Object.values(fromState).some((arr) => Array.isArray(arr) && arr.length > 0);
-
-      if (hasAny) {
-        setSelectedFilters(fromState as Record<TabLabel, string[]>);
-      } else {
-        // 서버 응답을 UI 라벨로 변환해 초기 선택 세팅
+      // 서버 응답을 UI 라벨로 변환해 초기 선택 세팅
         setSelectedFilters({
           "이용 목적": (res.purpose || []).map(toUiLabel),
           "공간 종류": res.type ? [toUiLabel(res.type)] : [],
@@ -107,7 +100,6 @@ const AdminEditSpacePage = () => {
           부가시설: (res.facilities || []).map(toUiLabel),
           지역: (res.location || []).map(toUiLabel),
         });
-      }
 
       setLoading(false);
     })();

--- a/src/pages/admin/AdminInitSpaceInfoPage.tsx
+++ b/src/pages/admin/AdminInitSpaceInfoPage.tsx
@@ -31,7 +31,7 @@ const AdminInitSpaceInfoPage = () => {
   const spaceFromKakao = location.state?.spaceFromKakao; // AdminConfirmSpacePage에서 전달받은 데이터
   const navigate = useNavigate();
   const { placeName } = location.state || { placeName: "공간명 없음" };
-  const [isLoading, setIsLoading] = useState(true);
+  // const [isLoading, setIsLoading] = useState(true);
 
   const [selectedFilters, setSelectedFilters] = useState<Record<TabLabel, string[]>>({
     "이용 목적": [],
@@ -44,7 +44,7 @@ const AdminInitSpaceInfoPage = () => {
   const [proposalId, setProposalId] = useState<number | null>(null);
 
   const fetchProposalId = async () => {
-    setIsLoading(true); // 로딩 시작
+    // setIsLoading(true); // 로딩 시작
     console.log("--- fetching proposal ID initiated ---");
     try {
       const response = await axiosInstance.get('/request/proposal', {
@@ -82,7 +82,7 @@ const AdminInitSpaceInfoPage = () => {
     } catch (error) {
       console.error("Error fetching proposal ID:", error);
     } finally {
-      setIsLoading(false); // 로딩 종료
+      // setIsLoading(false); // 로딩 종료
       console.log("--- fetching proposal ID finished ---");
     }
   };

--- a/src/pages/admin/AdminSearchSpacePage.tsx
+++ b/src/pages/admin/AdminSearchSpacePage.tsx
@@ -94,7 +94,6 @@ const AdminSearchSpacePage = () => {
       state: {
         placeName: space.name,
         space,
-        selectedFilters: draft?.filters ?? {},
       },
     });
   };


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #150 

## 📝 작업 내용

> 수정 페이지 진입 시, 이전에 검색했던 필터가 잘못 선택되는 오류 해결
- AdminSearchSpacePage에서 selectedFilters 전달 로직 삭제. 
- AdminEditSpacePage에서 서버 응답만 사용하도록 초기화 로직 단순화.
- AdminSearchSpacePage.tsx에서 selectedFilters 전달 로직 삭제

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 코드 리뷰어가 지정되어 있습니다. (디스코드 메시지로 대체)
- [x] 변경 사항에 대한 테스트를 진행했습니다.

